### PR TITLE
feature/dim_customers

### DIFF
--- a/models/marts/core/dim_customers.sql
+++ b/models/marts/core/dim_customers.sql
@@ -13,6 +13,14 @@ WITH
             {{ ref('fct_orders') }}
     ),
 
+    professions AS (
+        SELECT
+            CAST(customer_id AS STRING) AS customer_id
+            ,job 
+        FROM    
+            {{ ref('professions') }}
+    ),
+
     customer_orders AS (
         SELECT
             customer_id
@@ -31,6 +39,7 @@ WITH
             customers.customer_id
             ,customers.first_name
             ,customers.last_name
+            ,professions.job
             ,customer_orders.first_order_date
             ,customer_orders.most_recent_order_date
             ,COALESCE(customer_orders.number_of_orders, 0) AS number_of_orders
@@ -40,6 +49,10 @@ WITH
         LEFT JOIN 
             customer_orders 
         USING 
+            (customer_id)
+        LEFT JOIN
+            professions
+        USING
             (customer_id)
     )
 

--- a/seeds/professions.csv
+++ b/seeds/professions.csv
@@ -1,0 +1,9 @@
+customer_id,job
+1, Cooker
+2, Software Developer
+3, Data Scientist
+4, Data Analyst
+5, Data Engineer
+20, Analytics Engineer
+21, Architect
+23, Mentor


### PR DESCRIPTION
# 1. Introduction

The stakeholders want to be able to segment their customers by their job profile, so they want this additional dimension to appear in the customers' dashboard.

# 2. Modification provided with the PR

Added additional contents :
- A dbt seed that contains the jobs of the customers
- A new dimension in the model `dim_customers`, called `customer_job`

# 3. Before/After - DBT Lineage

Current lineage of the model `dim_customers`
![Capture d’écran 2022-01-13 à 16 11 48](https://user-images.githubusercontent.com/43753671/149358114-b677d357-c901-4cd8-a0ae-dad2cb97231a.png)

Lineage of the model `dim_customers` after the PR deployment
![Capture d’écran 2022-01-13 à 16 14 06](https://user-images.githubusercontent.com/43753671/149358199-12201228-a63b-4d75-b4ad-81dc67aa47d2.png)



